### PR TITLE
Add Modal To The Stake ButtonAdd modal clean final

### DIFF
--- a/components/nft/nft-assets/nft-assets.types.ts
+++ b/components/nft/nft-assets/nft-assets.types.ts
@@ -1,0 +1,3 @@
+export interface StakingAssetsItemStakeModalProps {
+  onProceed: () => void;
+}

--- a/components/nft/nft-assets/staking-assets-item-modals.tsx
+++ b/components/nft/nft-assets/staking-assets-item-modals.tsx
@@ -2,8 +2,11 @@ import { Button, Div, P, Span } from '@stylin.js/elements';
 import Link from 'next/link';
 import { FC } from 'react';
 import { useState } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
 
 import { useModal } from '@/hooks/use-modal';
+
+import { StakingAssetsItemStakeModalProps } from './staking-assets-item.hooks/nft-assets.types';
 
 export const StakingAssetsItemWithdrawModal: FC = () => {
   const { handleClose } = useModal();
@@ -134,18 +137,17 @@ export const StakingAssetsItemUnstakeModal: FC = () => {
   );
 };
 
-type Props = {
-  onProceed: () => void;
-};
-
-export const StakingAssetsItemStakeModal: FC<Props> = ({ onProceed }) => {
+export const StakingAssetsItemStakeModal: FC<
+  StakingAssetsItemStakeModalProps
+> = ({ onProceed }) => {
   const { handleClose } = useModal();
+
   const [neverShow, setNeverShow] = useState(false);
+  const [, setHideModal] = useLocalStorage('hideStakeModal', false);
 
   const handleProceed = () => {
-    // If the checkbox is ticked, save the flag so the modal won't show next time.
     if (neverShow) {
-      localStorage.setItem('hideStakeModal', 'true');
+      setHideModal(true);
     }
     handleClose();
     onProceed(); // Call the actual staking function

--- a/components/nft/nft-assets/staking-assets-item-modals.tsx
+++ b/components/nft/nft-assets/staking-assets-item-modals.tsx
@@ -1,6 +1,7 @@
 import { Button, Div, P, Span } from '@stylin.js/elements';
 import Link from 'next/link';
 import { FC } from 'react';
+import { useState } from 'react';
 
 import { useModal } from '@/hooks/use-modal';
 
@@ -129,6 +130,92 @@ export const StakingAssetsItemUnstakeModal: FC = () => {
           Unstake
         </Button>
       </Link>
+    </Div>
+  );
+};
+
+type Props = {
+  onProceed: () => void;
+};
+
+export const StakingAssetsItemStakeModal: FC<Props> = ({ onProceed }) => {
+  const { handleClose } = useModal();
+  const [neverShow, setNeverShow] = useState(false);
+
+  const handleProceed = () => {
+    // If the checkbox is ticked, save the flag so the modal won't show next time.
+    if (neverShow) {
+      localStorage.setItem('hideStakeModal', 'true');
+    }
+    handleClose();
+    onProceed(); // Call the actual staking function
+  };
+  return (
+    <Div
+      p="1.5rem"
+      width="100%"
+      gap="1.5rem"
+      color="#ffffff"
+      display="flex"
+      maxWidth="27rem"
+      lineHeight="160%"
+      textAlign="center"
+      fontSize="0.875rem"
+      borderRadius="1rem"
+      flexDirection="column"
+      backdropFilter="blur(20px)"
+      bg="rgba(255, 255, 255, 0.10)"
+    >
+      <Div display="flex" justifyContent="space-between" alignItems="center">
+        <P fontSize="1.25rem" fontWeight="600">
+          You Are Minting an Nft
+        </P>
+        <Span
+          py="0.25rem"
+          px="0.75rem"
+          bg="#FFFFFF1A"
+          display="flex"
+          fontWeight="500"
+          cursor="pointer"
+          borderRadius="0.5rem"
+          onClick={handleClose}
+        >
+          ESC
+        </Span>
+      </Div>
+      <P>You are minting an NFT.</P>
+      <Div
+        display="flex"
+        alignItems="center"
+        gap="0.5rem"
+        justifyContent="center"
+      >
+        <input
+          type="checkbox"
+          checked={neverShow}
+          onChange={(e) => setNeverShow(e.target.checked)}
+        />
+        <P m="0" fontSize="0.875rem">
+          Never show again
+        </P>
+      </Div>
+
+      <Button
+        all="unset"
+        py="1rem"
+        px="1.5rem"
+        bg="#99EFE4"
+        color="#0C0F1D"
+        cursor="pointer"
+        fontWeight="500"
+        textAlign="center"
+        position="relative"
+        borderRadius="0.625rem"
+        width="calc(100% - 3rem)"
+        onClick={handleProceed}
+      >
+        Proceed to Stake
+      </Button>
     </Div>
   );
 };

--- a/components/nft/nft-assets/staking-assets-item-modals.tsx
+++ b/components/nft/nft-assets/staking-assets-item-modals.tsx
@@ -6,7 +6,7 @@ import { useLocalStorage } from 'usehooks-ts';
 
 import { useModal } from '@/hooks/use-modal';
 
-import { StakingAssetsItemStakeModalProps } from './staking-assets-item.hooks/nft-assets.types';
+import { StakingAssetsItemStakeModalProps } from './nft-assets.types';
 
 export const StakingAssetsItemWithdrawModal: FC = () => {
   const { handleClose } = useModal();


### PR DESCRIPTION
Added A modal to the staking button, modfification in **(components/stake/stake-form/stake-form-button/stake-form-button.hooks/index.tsx )** and 
**(components/nft/nft-assets/staking-assets-item-modals.tsx)**

When the stake button is clicked  it triggers the onStake function  which checks if the user has previously ticked the never show again checkbox, and if false then triggers the modal to pop up ,user clicks "proceed to stake" button on the modal, that  triggers the handleComfirmedStake function that contains the stake logic, 
also its been passed as onProceed as a prop to the modal .



